### PR TITLE
@react-maps/world fix: svg viewBox update

### DIFF
--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@react-map/world",
-    "version": "1.0.7",
+    "version": "1.0.9",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/packages/world/src/constants.ts
+++ b/packages/world/src/constants.ts
@@ -6,7 +6,7 @@ export const constants = {
   HOVERCOLOR: '#303030',
   SELECTED_COLOR: '#ff0000',
 };
-export const viewBox = '0 -20 1500 700';
+export const viewBox = '0 -20 1010 690';
 export const stateCode = [
   'Andorra',
   'United Arab Emirates',


### PR DESCRIPTION
viewBox size is incorrect for the world map. 
Currently it looks like this:
![Zrzut ekranu 2024-08-06 112723](https://github.com/user-attachments/assets/35483c50-3500-4d76-90dd-78243d4950ce)

After the change:
![Zrzut ekranu 2024-08-06 110647](https://github.com/user-attachments/assets/45e429d8-8c04-4990-aaa2-c90c0644725f)

Btw, you already fixed it before with this commit: https://github.com/shubhexists/react-maps/commit/29a2c92f226762e18f001d3033bc52549034f766
but then overrode it with this one: https://github.com/shubhexists/react-maps/commit/00fbe063aa738940155468471f781be874594c00 when you moved viewBox size to constants

