### PR TITLE
@react-maps/usa fix: svg viewBox update

### DIFF
--- a/packages/usa/package.json
+++ b/packages/usa/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@react-map/usa",
-    "version": "1.0.5",
+    "version": "1.0.7",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",

--- a/packages/usa/src/constants.ts
+++ b/packages/usa/src/constants.ts
@@ -6,7 +6,7 @@ export const constants = {
   HOVERCOLOR: '#303030',
   SELECTED_COLOR: '#ff0000',
 };
-export const viewBox = '50 -20 1700 900';
+export const viewBox = '100 -20 1150 800';
 export const stateCode = [
   'Alaska',
   'Alabama',


### PR DESCRIPTION
Similar to another PR I opened https://github.com/shubhexists/react-maps/pull/20

viewBox size is incorrect for the USA map.
Currently it looks like this:
![Zrzut ekranu 2024-08-06 130527](https://github.com/user-attachments/assets/c8fbe69f-6062-4bc0-829b-5bced08330bf)

After the change:
![Zrzut ekranu 2024-08-06 130603](https://github.com/user-attachments/assets/71748f68-a95f-4112-a4d9-c43be687bac7)


